### PR TITLE
Update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@ This pipeline fits a multi-tensor model to diffusion-weighted imaging (DWI) data
 Should you use this pipeline for your research, **please cite the following**
 
 ```
-Dhollander, T., Emsell, L., Van Hecke, W., Maes, F., Sunaert, S., Suetens, P. (2014). Track Orientation Density Imaging (TODI) and Track Orientation Distribution (TOD) based tractography. NeuroImage, 94, 312-336. https://doi.org/10.1016/j.neuroimage.2013.12.047
+Dhollander, T., Emsell, L., Van Hecke, W., Maes, F., Sunaert, S., Suetens, P. (2014).
+Track Orientation Density Imaging (TODI) and Track Orientation Distribution (TOD) based tractography.
+NeuroImage, 94, 312-336. https://doi.org/10.1016/j.neuroimage.2013.12.047
 
-Coronado-Leija, R., Ramirez-Manzanares, A., Marroquin, J.L. (2017). Estimation of individual axon bundle properties by a Multi-Resolution Discrete-Search method. Medical Image Analysis, 42, 26-43. https://doi.org/10.1016/j.media.2017.06.008
+Coronado-Leija, R., Ramirez-Manzanares, A., Marroquin, J.L. (2017).
+Estimation of individual axon bundle properties by a Multi-Resolution Discrete-Search method.
+Medical Image Analysis, 42, 26-43. https://doi.org/10.1016/j.media.2017.06.008
 
-Hernandez-Gutierrez, E., Coronado-Leija, R., Ramirez-Manzanares, A., Barakovic, M., Magon, S., Descoteaux, M. (2023). Improving Multi-Tensor Fitting with Global Information from Track Orientation Density Imaging. In: Karaman, M., Mito, R., Powell, E., Rheault, F., Winzeck, S. (eds) Computational Diffusion MRI. CDMRI 2023. Lecture Notes in Computer Science, vol 14328. Springer, Cham. https://doi.org/10.1007/978-3-031-47292-3_4
+Hernandez-Gutierrez, E., Coronado-Leija, R., Ramirez-Manzanares, A., Barakovic, M., Magon, S., Descoteaux, M. (2023).
+Improving Multi-Tensor Fitting with Global Information from Track Orientation Density Imaging.
+Computational Diffusion MRI. CDMRI 2023. Lecture Notes in Computer Science, vol 14328. Springer, Cham. https://doi.org/10.1007/978-3-031-47292-3_4
 ```
 
 Requeriments
@@ -27,15 +33,15 @@ If you have Apptainer (Singularity), build the .sif image with:
 `singularity build mrds-flow_dev.sif docker://scilus/mrds-flow:dev`.
 
 Then, launch your Nextflow command with:
-`-with-singularity ABSOLUTE_PATH/mrds-flow_dev.sif`
+`-with-singularity ABSOLUTE_PATH/mrds-flow_dev.sif`.
 
 If you are on MacOS or Windows, we recommend using the Docker container to run mrds_flow pipeline.
 
 Pull the image with:
-`docker pull https://hub.docker.com/r/scilus/mrds-flow`
+`docker pull https://hub.docker.com/r/scilus/mrds-flow`.
 
 Launch your Nextflow command with:
-`-with-docker scilus/mrds-flow:dev`
+`-with-docker scilus/mrds-flow:dev`.
 
 Usage
 -----

--- a/USAGE
+++ b/USAGE
@@ -51,6 +51,39 @@ macos                                    When this profile is used, mrds_flow wi
 
 cbrain                                   When this profile is used, Nextflow will copy all the output files in publishDir and not use symlinks.
 
+OUTPUT
+
+The output files have the following format:
+
+`results_MRDS_<method>_<modsel>_<metric>.nii.gz`,
+
+where
+
+<method> represents the method used by MRDS to fit the multi-tensors at each voxel.
+There are 3 different methods:
+    'Fixed': All tensors eigenvalues are fixed.
+    'Equal': All tensors eigenvalues are estimated assuming all tensors are equal.
+    'Diff':  All tensors eigenvalues are estimated differently.
+
+<modsel> represents the model selection used by MRDS to estimate the number of
+tensors per voxel. There are 5 different models:
+    'V1': All voxels have exactly 1 tensors.
+    'V2': All voxels have exactly 2 tensors.
+    'V3': All voxels have exactly 3 tensors.
+    'BIC': Bayesian Information Criteria (BIC) determinates the number of tensors
+    'TODI': Track Orientation Distribution Imagining (TODI) determinates the number of tensors.
+
+<metric> represents the actual metric stored in the file. There 
+    'FA': fixel-FA metric
+    'RD': fixel-RD metric
+    'AD': fixel-AD metric
+    'MD': fixel-MD metric
+    'PDDs_CARTESIAN': Principal diffusion directions of the tensors
+    'NUM_COMP': Number of tensors
+    'COMP_SIZE': Compartment sizes of the tensors
+    'ISOTROPIC': Isotropic volumen fraction and diffusivity
+    'EIGENVALUES': Eigenvalues of the tensors.
+
 NOTES
 
 The 'scilpy/scripts' and MRDS bin folders should be in your PATH environment variable. Not necessary if the

--- a/main.nf
+++ b/main.nf
@@ -275,12 +275,13 @@ process Compute_TODI {
     """
     scil_compute_todi.py ${tractogram} --out_todi_sh ${sid}__MRDS_Diff_${params.model_selection}_TOD_SH.nii.gz \
         --reference ${dwi} \
-        --sh_basis tournier07 -f
+        --sh_basis descoteaux07 -f
 
     scil_compute_fodf_metrics.py ${sid}__MRDS_Diff_${params.model_selection}_TOD_SH.nii.gz \
         --nufo ${sid}__MRDS_Diff_${params.model_selection}_TOD_NUFO.nii.gz \
         --not_all \
-        --sh_basis tournier07 --rt 0.2 -f
+        --sh_basis descoteaux07 \
+        --rt 0.2 -f
     """
 }
 


### PR DESCRIPTION
1. Added more documentation in the README and USAGE about the output tree format. Changed sh_basis for the SH output images from tournier07 to descoteaux07.
2., 3. and 4. Added detailed description of the output tree format of each file.

TODO

- [ ] Delete output TOD images after usage to reduce storage usage.
- [x] Delete unused output files from Fit_MRDS
- [x] Add relative threshold flag for TODI